### PR TITLE
README: Make example a little bit more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@ A python script to help debug `-Wframe-larger-than=` warnings.
 
 ## Example
 
+Build an object file, such as with the Linux kernel.
+
 ```sh
 $  make CC=clang arch/x86/kernel/kvm.o CFLAGS=-Wframe-larger-than=1000
 ...
 arch/x86/kernel/kvm.c:494:13: warning: stack frame size of 1064 bytes in function 'kvm_send_ipi_mask_allbutself' [-Wframe-larger-than=]
 static void kvm_send_ipi_mask_allbutself(const struct cpumask *mask, int vector)
             ^
+```
+
+Run `frame_larger_than.py` on that object file with the function name that triggers the warning to see the function's stack usage.
+
+```sh
 $ frame_larger_than.py arch/x86/kernel/kvm.o kvm_send_ipi_mask_allbutself
 kvm_send_ipi_mask_allbutself:
         1024    struct cpumask          new_mask


### PR DESCRIPTION
- Separate the object file generation command section from the running `frame_larger_than.py` section to make it easier to understand at quick glance.

- Add a description of what each command does to help clarify what is needed at each step.

Closes: https://github.com/ClangBuiltLinux/frame-larger-than/issues/9
